### PR TITLE
💖 Fix background highlight color & Format `colors.lua`

### DIFF
--- a/lua/lualine/themes/onedark.lua
+++ b/lua/lualine/themes/onedark.lua
@@ -4,35 +4,35 @@ local colors = require("onedark.colors").setup(config)
 local onedark = {}
 
 onedark.normal = {
-  a = { bg = colors.green, fg = colors.black },
-  b = { bg = colors.fg_gutter, fg = colors.green },
-  c = { bg = colors.bg_statusline, fg = colors.fg_sidebar },
+  a = {bg = colors.green, fg = colors.black},
+  b = {bg = colors.fg_gutter, fg = colors.green},
+  c = {bg = colors.bg_statusline, fg = colors.fg_sidebar}
 }
 
 onedark.insert = {
-  a = { bg = colors.blue, fg = colors.black },
-  b = { bg = colors.fg_gutter, fg = colors.blue },
+  a = {bg = colors.blue, fg = colors.black},
+  b = {bg = colors.fg_gutter, fg = colors.blue}
 }
 
 onedark.command = {
-  a = { bg = colors.purple, fg = colors.black },
-  b = { bg = colors.fg_gutter, fg = colors.purple },
+  a = {bg = colors.purple, fg = colors.black},
+  b = {bg = colors.fg_gutter, fg = colors.purple}
 }
 
 onedark.visual = {
-  a = { bg = colors.yellow, fg = colors.black },
-  b = { bg = colors.fg_gutter, fg = colors.yellow },
+  a = {bg = colors.yellow, fg = colors.black},
+  b = {bg = colors.fg_gutter, fg = colors.yellow}
 }
 
 onedark.replace = {
-  a = { bg = colors.red, fg = colors.black },
-  b = { bg = colors.fg_gutter, fg = colors.red },
+  a = {bg = colors.red, fg = colors.black},
+  b = {bg = colors.fg_gutter, fg = colors.red}
 }
 
 onedark.inactive = {
-  a = { bg = colors.bg_statusline, fg = colors.blue },
-  b = { bg = colors.bg_statusline, fg = colors.fg_gutter, gui = "bold" },
-  c = { bg = colors.bg_statusline, fg = colors.fg_gutter },
+  a = {bg = colors.bg_statusline, fg = colors.blue},
+  b = {bg = colors.bg_statusline, fg = colors.fg_gutter, gui = "bold"},
+  c = {bg = colors.bg_statusline, fg = colors.fg_gutter}
 }
 
 return onedark

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -14,10 +14,10 @@ function M.setup(config)
   colors = {
     none = "NONE",
     bg = "#282c34",
-    bg2 = '#21252b',
-    bg_visual = '#393f4a',
-    border = '#646e82',
-    bg_highlight = "#242b38",
+    bg2 = "#21252b",
+    bg_visual = "#393f4a",
+    border = "#646e82",
+    bg_highlight = "#2c313a",
     fg = "#abb2bf",
     fg_light = "#adbac7",
     fg_dark = "#798294",
@@ -29,12 +29,12 @@ function M.setup(config)
     orange = "#d19a66",
     yellow = "#e0af68",
     yellow2 = "#e2c08d",
-    bg_yellow = '#ebd09c',
+    bg_yellow = "#ebd09c",
     green = "#98c379",
     red = "#e86671",
     red1 = "#f65866",
-    git = { change = "#e0af68", add = "#109868", delete = "#9A353D", conflict = "#bb7a61" },
-    gitSigns = { change = "#e0af68", add = "#109868", delete = "#9A353D" },
+    git = {change = "#e0af68", add = "#109868", delete = "#9A353D", conflict = "#bb7a61"},
+    gitSigns = {change = "#e0af68", add = "#109868", delete = "#9A353D"}
   }
 
   util.bg = colors.bg
@@ -43,13 +43,13 @@ function M.setup(config)
     add = util.darken(colors.git.add, 0.15),
     delete = util.darken(colors.git.delete, 0.15),
     change = util.darken(colors.git.change, 0.15),
-    text = colors.fg_gutter,
+    text = colors.fg_gutter
   }
 
   colors.gitSigns = {
     add = util.brighten(colors.gitSigns.add, 0.2),
     change = util.brighten(colors.gitSigns.change, 0.2),
-    delete = util.brighten(colors.gitSigns.delete, 0.2),
+    delete = util.brighten(colors.gitSigns.delete, 0.2)
   }
 
   colors.git.ignore = colors.fg_gutter

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -2,7 +2,7 @@
 local config
 
 -- shim vim for kitty and other generators
-vim = vim or { g = {}, o = {} }
+vim = vim or {g = {}, o = {}}
 
 local function opt(key, default)
   key = "onedark_" .. key
@@ -27,7 +27,7 @@ config = {
   dev = opt("dev", false),
   darkFloat = opt("dark_float", true),
   darkSidebar = opt("dark_sidebar", true),
-  transform_colors = false,
+  transform_colors = false
 }
 
 return config

--- a/lua/onedark/hsluv.lua
+++ b/lua/onedark/hsluv.lua
@@ -50,7 +50,7 @@ hsluv.get_bounds = function(l)
       local top1 = (284517 * m1 - 94839 * m3) * sub2
       local top2 = (838422 * m3 + 769860 * m2 + 731718 * m1) * l * sub2 - 769860 * t * l
       local bottom = (632260 * m3 - 126452 * m2) * sub2 + 126452 * t
-      table.insert(result, { slope = top1 / bottom, intercept = top2 / bottom })
+      table.insert(result, {slope = top1 / bottom, intercept = top2 / bottom})
     end
   end
   return result
@@ -112,16 +112,16 @@ hsluv.xyz_to_rgb = function(tuple)
   return {
     hsluv.from_linear(hsluv.dot_product(hsluv.m[1], tuple)),
     hsluv.from_linear(hsluv.dot_product(hsluv.m[2], tuple)),
-    hsluv.from_linear(hsluv.dot_product(hsluv.m[3], tuple)),
+    hsluv.from_linear(hsluv.dot_product(hsluv.m[3], tuple))
   }
 end
 
 hsluv.rgb_to_xyz = function(tuple)
-  local rgbl = { hsluv.to_linear(tuple[1]), hsluv.to_linear(tuple[2]), hsluv.to_linear(tuple[3]) }
+  local rgbl = {hsluv.to_linear(tuple[1]), hsluv.to_linear(tuple[2]), hsluv.to_linear(tuple[3])}
   return {
     hsluv.dot_product(hsluv.minv[1], rgbl),
     hsluv.dot_product(hsluv.minv[2], rgbl),
-    hsluv.dot_product(hsluv.minv[3], rgbl),
+    hsluv.dot_product(hsluv.minv[3], rgbl)
   }
 end
 
@@ -156,9 +156,9 @@ hsluv.xyz_to_luv = function(tuple)
   end
   local L = hsluv.y_to_l(Y)
   if L == 0 then
-    return { 0, 0, 0 }
+    return {0, 0, 0}
   end
-  return { L, 13 * L * (varU - hsluv.refU), 13 * L * (varV - hsluv.refV) }
+  return {L, 13 * L * (varU - hsluv.refU), 13 * L * (varV - hsluv.refV)}
 end
 
 hsluv.luv_to_xyz = function(tuple)
@@ -166,13 +166,13 @@ hsluv.luv_to_xyz = function(tuple)
   local U = tuple[2]
   local V = tuple[3]
   if L == 0 then
-    return { 0, 0, 0 }
+    return {0, 0, 0}
   end
   local varU = U / (13 * L) + hsluv.refU
   local varV = V / (13 * L) + hsluv.refV
   local Y = hsluv.l_to_y(L)
   local X = 0 - (9 * Y * varU) / (((varU - 4) * varV) - varU * varV)
-  return { X, Y, (9 * Y - 15 * varV * Y - varV * X) / (3 * varV) }
+  return {X, Y, (9 * Y - 15 * varV * Y - varV * X) / (3 * varV)}
 end
 
 hsluv.luv_to_lch = function(tuple)
@@ -189,14 +189,14 @@ hsluv.luv_to_lch = function(tuple)
       H = 360 + H
     end
   end
-  return { L, C, H }
+  return {L, C, H}
 end
 
 hsluv.lch_to_luv = function(tuple)
   local L = tuple[1]
   local C = tuple[2]
   local Hrad = tuple[3] / 360.0 * 2 * math.pi
-  return { L, math.cos(Hrad) * C, math.sin(Hrad) * C }
+  return {L, math.cos(Hrad) * C, math.sin(Hrad) * C}
 end
 
 hsluv.hsluv_to_lch = function(tuple)
@@ -204,12 +204,12 @@ hsluv.hsluv_to_lch = function(tuple)
   local S = tuple[2]
   local L = tuple[3]
   if L > 99.9999999 then
-    return { 100, 0, H }
+    return {100, 0, H}
   end
   if L < 0.00000001 then
-    return { 0, 0, H }
+    return {0, 0, H}
   end
-  return { L, hsluv.max_safe_chroma_for_lh(L, H) / 100 * S, H }
+  return {L, hsluv.max_safe_chroma_for_lh(L, H) / 100 * S, H}
 end
 
 hsluv.lch_to_hsluv = function(tuple)
@@ -218,13 +218,13 @@ hsluv.lch_to_hsluv = function(tuple)
   local H = tuple[3]
   local max_chroma = hsluv.max_safe_chroma_for_lh(L, H)
   if L > 99.9999999 then
-    return { H, 0, 100 }
+    return {H, 0, 100}
   end
   if L < 0.00000001 then
-    return { H, 0, 0 }
+    return {H, 0, 0}
   end
 
-  return { H, C / max_chroma * 100, L }
+  return {H, C / max_chroma * 100, L}
 end
 
 hsluv.hpluv_to_lch = function(tuple)
@@ -232,12 +232,12 @@ hsluv.hpluv_to_lch = function(tuple)
   local S = tuple[2]
   local L = tuple[3]
   if L > 99.9999999 then
-    return { 100, 0, H }
+    return {100, 0, H}
   end
   if L < 0.00000001 then
-    return { 0, 0, H }
+    return {0, 0, H}
   end
-  return { L, hsluv.max_safe_chroma_for_l(L) / 100 * S, H }
+  return {L, hsluv.max_safe_chroma_for_l(L) / 100 * S, H}
 end
 
 hsluv.lch_to_hpluv = function(tuple)
@@ -245,12 +245,12 @@ hsluv.lch_to_hpluv = function(tuple)
   local C = tuple[2]
   local H = tuple[3]
   if L > 99.9999999 then
-    return { H, 0, 100 }
+    return {H, 0, 100}
   end
   if L < 0.00000001 then
-    return { H, 0, 0 }
+    return {H, 0, 0}
   end
-  return { H, C / hsluv.max_safe_chroma_for_l(L) * 100, L }
+  return {H, C / hsluv.max_safe_chroma_for_l(L) * 100, L}
 end
 
 hsluv.rgb_to_hex = function(tuple)
@@ -320,14 +320,14 @@ hsluv.hex_to_hpluv = function(s)
 end
 
 hsluv.m = {
-  { 3.240969941904521, -1.537383177570093, -0.498610760293 },
-  { -0.96924363628087, 1.87596750150772, 0.041555057407175 },
-  { 0.055630079696993, -0.20397695888897, 1.056971514242878 },
+  {3.240969941904521, -1.537383177570093, -0.498610760293},
+  {-0.96924363628087, 1.87596750150772, 0.041555057407175},
+  {0.055630079696993, -0.20397695888897, 1.056971514242878}
 }
 hsluv.minv = {
-  { 0.41239079926595, 0.35758433938387, 0.18048078840183 },
-  { 0.21263900587151, 0.71516867876775, 0.072192315360733 },
-  { 0.019330818715591, 0.11919477979462, 0.95053215224966 },
+  {0.41239079926595, 0.35758433938387, 0.18048078840183},
+  {0.21263900587151, 0.71516867876775, 0.072192315360733},
+  {0.019330818715591, 0.11919477979462, 0.95053215224966}
 }
 hsluv.refY = 1.0
 hsluv.refU = 0.19783000664283

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -32,7 +32,7 @@ function M.setup(config)
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal
     ErrorMsg = {fg = c.error}, -- error messages on the command line
-    VertSplit = {fg = c.bg1}, -- the column separating vertically split windows
+    VertSplit = {fg = c.bg}, -- the column separating vertically split windows
     Folded = {fg = c.blue, bg = c.fg_gutter}, -- line used for closed folds
     FoldColumn = {bg = c.bg, fg = c.fg_gutter}, -- 'foldcolumn'
     SignColumn = {bg = config.transparent and c.none or c.bg, fg = c.fg_gutter}, -- column where |signs| are displayed

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -32,7 +32,7 @@ function M.setup(config)
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal
     ErrorMsg = {fg = c.error}, -- error messages on the command line
-    VertSplit = {fg = c.bg2}, -- the column separating vertically split windows
+    VertSplit = {fg = c.bg1}, -- the column separating vertically split windows
     Folded = {fg = c.blue, bg = c.fg_gutter}, -- line used for closed folds
     FoldColumn = {bg = c.bg, fg = c.fg_gutter}, -- 'foldcolumn'
     SignColumn = {bg = config.transparent and c.none or c.bg, fg = c.fg_gutter}, -- column where |signs| are displayed

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -283,6 +283,7 @@ function M.setup(config)
     NvimTreeImageFile = {fg = c.fg_sidebar},
     NvimTreeSymlink = {fg = c.purple},
     NvimTreeFolderName = {fg = c.fg_light},
+    NvimTreeOpenedFolderName = {fg = c.fg_light, style = "bold"},
     LspDiagnosticsError = {fg = c.error},
     LspDiagnosticsWarning = {fg = c.warning},
     LspDiagnosticsInformation = {fg = c.info},

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -15,162 +15,151 @@ function M.setup(config)
   local c = theme.colors
 
   theme.base = {
-    Comment = { fg = c.fg_gutter, style = config.commentStyle }, -- any comment
-    ColorColumn = { bg = c.bg_visual }, -- used for the columns set with 'colorcolumn'
-    Conceal = { fg = c.fg_gutter }, -- placeholder characters substituted for concealed text (see 'conceallevel')
-    Cursor = { fg = c.bg, bg = c.fg }, -- character under the cursor
-    lCursor = { fg = c.bg, bg = c.fg }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-    CursorIM = { fg = c.bg, bg = c.fg }, -- like Cursor, but used when in IME mode |CursorIM|
-    CursorColumn = { bg = c.bg_highlight }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
-    CursorLine = { bg = c.bg_highlight }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
-    Directory = { fg = c.blue }, -- directory names (and other special names in listings)
-    DiffAdd = { bg = c.diff.add }, -- diff mode: Added line |diff.txt|
-    DiffChange = { bg = c.diff.change }, -- diff mode: Changed line |diff.txt|
-    DiffDelete = { bg = c.diff.delete }, -- diff mode: Deleted line |diff.txt|
-    DiffText = { bg = c.diff.text }, -- diff mode: Changed text within a changed line |diff.txt|
-    EndOfBuffer = { fg = c.bg }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+    Comment = {fg = c.fg_gutter, style = config.commentStyle}, -- any comment
+    ColorColumn = {bg = c.bg_visual}, -- used for the columns set with 'colorcolumn'
+    Conceal = {fg = c.fg_gutter}, -- placeholder characters substituted for concealed text (see 'conceallevel')
+    Cursor = {fg = c.bg, bg = c.fg}, -- character under the cursor
+    lCursor = {fg = c.bg, bg = c.fg}, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+    CursorIM = {fg = c.bg, bg = c.fg}, -- like Cursor, but used when in IME mode |CursorIM|
+    CursorColumn = {bg = c.bg_highlight}, -- Screen-column at the cursor, when 'cursorcolumn' is set.
+    CursorLine = {bg = c.bg_highlight}, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
+    Directory = {fg = c.blue}, -- directory names (and other special names in listings)
+    DiffAdd = {bg = c.diff.add}, -- diff mode: Added line |diff.txt|
+    DiffChange = {bg = c.diff.change}, -- diff mode: Changed line |diff.txt|
+    DiffDelete = {bg = c.diff.delete}, -- diff mode: Deleted line |diff.txt|
+    DiffText = {bg = c.diff.text}, -- diff mode: Changed text within a changed line |diff.txt|
+    EndOfBuffer = {fg = c.bg}, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal
-    ErrorMsg = { fg = c.error }, -- error messages on the command line
-    VertSplit = { fg = c.border }, -- the column separating vertically split windows
-    Folded = { fg = c.blue, bg = c.fg_gutter }, -- line used for closed folds
-    FoldColumn = { bg = c.bg, fg = c.fg_gutter }, -- 'foldcolumn'
-    SignColumn = { bg = config.transparent and c.none or c.bg, fg = c.fg_gutter }, -- column where |signs| are displayed
-    SignColumnSB = { bg = c.bg_sidebar, fg = c.fg_gutter }, -- column where |signs| are displayed
-    Substitute = { bg = c.red, fg = c.black }, -- |:substitute| replacement text highlighting
-    LineNr = { fg = c.fg_gutter }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
-    CursorLineNr = { fg = c.dark5 }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
-    MatchParen = { fg = c.orange, style = "bold" }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
-    ModeMsg = { fg = c.fg_dark, style = "bold" }, -- 'showmode' message (e.g., "-- INSERT -- ")
-    MsgArea = { fg = c.fg_dark }, -- Area for messages and cmdline
+    ErrorMsg = {fg = c.error}, -- error messages on the command line
+    VertSplit = {fg = c.border}, -- the column separating vertically split windows
+    Folded = {fg = c.blue, bg = c.fg_gutter}, -- line used for closed folds
+    FoldColumn = {bg = c.bg, fg = c.fg_gutter}, -- 'foldcolumn'
+    SignColumn = {bg = config.transparent and c.none or c.bg, fg = c.fg_gutter}, -- column where |signs| are displayed
+    SignColumnSB = {bg = c.bg_sidebar, fg = c.fg_gutter}, -- column where |signs| are displayed
+    Substitute = {bg = c.red, fg = c.black}, -- |:substitute| replacement text highlighting
+    LineNr = {fg = c.fg_gutter}, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
+    CursorLineNr = {fg = c.dark5}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
+    MatchParen = {fg = c.orange, style = "bold"}, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
+    ModeMsg = {fg = c.fg_dark, style = "bold"}, -- 'showmode' message (e.g., "-- INSERT -- ")
+    MsgArea = {fg = c.fg_dark}, -- Area for messages and cmdline
     -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
-    MoreMsg = { fg = c.blue }, -- |more-prompt|
-    NonText = { fg = c.bg }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
-    Normal = { fg = c.fg, bg = config.transparent and c.none or c.bg }, -- normal text
-    NormalNC = { fg = c.fg, bg = config.transparent and c.none or c.bg }, -- normal text in non-current windows
-    NormalSB = { fg = c.fg_sidebar, bg = c.bg_sidebar }, -- normal text in non-current windows
-    NormalFloat = { fg = c.fg, bg = c.bg_float }, -- Normal text in floating windows.
-    FloatBorder = { fg = c.border_highlight },
-    Pmenu = { bg = c.bg_popup, fg = c.fg }, -- Popup menu: normal item.
-    PmenuSel = { bg = util.darken(c.fg_gutter, 0.8) }, -- Popup menu: selected item.
-    PmenuSbar = { bg = util.lighten(c.bg_popup, 0.95) }, -- Popup menu: scrollbar.
-    PmenuThumb = { bg = c.fg_gutter }, -- Popup menu: Thumb of the scrollbar.
-    Question = { fg = c.blue }, -- |hit-enter| prompt and yes/no questions
-    QuickFixLine = { bg = c.bg_visual, style = "bold" }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
-    Search = { bg = c.bg_search, fg = c.fg_search }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
-    IncSearch = { bg = c.orange, fg = c.black }, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
-    SpecialKey = { fg = c.fg_gutter }, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
-    SpellBad = { sp = c.error, style = "undercurl" }, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.
-    SpellCap = { sp = c.warning, style = "undercurl" }, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
-    SpellLocal = { sp = c.info, style = "undercurl" }, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
-    SpellRare = { sp = c.hint, style = "undercurl" }, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
-    StatusLine = { fg = c.fg_sidebar, bg = c.bg_statusline }, -- status line of current window
-    StatusLineNC = { fg = c.fg_gutter, bg = c.bg_statusline }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
-    TabLine = { bg = c.bg_statusline, fg = c.fg_gutter }, -- tab pages line, not active tab page label
-    TabLineFill = { bg = c.black }, -- tab pages line, where there are no labels
-    TabLineSel = { fg = c.black, bg = c.blue }, -- tab pages line, active tab page label
-    Title = { fg = c.blue, style = "bold" }, -- titles for output from ":set all", ":autocmd" etc.
-    Visual = { bg = c.bg_visual }, -- Visual mode selection
-    VisualNOS = { bg = c.bg_visual }, -- Visual mode selection when vim is "Not Owning the Selection".
-    WarningMsg = { fg = c.warning }, -- warning messages
-    Whitespace = { fg = c.fg_gutter }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
-    WildMenu = { bg = c.bg_visual }, -- current match in 'wildmenu' completion
-
+    MoreMsg = {fg = c.blue}, -- |more-prompt|
+    NonText = {fg = c.bg}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
+    Normal = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text
+    NormalNC = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text in non-current windows
+    NormalSB = {fg = c.fg_sidebar, bg = c.bg_sidebar}, -- normal text in non-current windows
+    NormalFloat = {fg = c.fg, bg = c.bg_float}, -- Normal text in floating windows.
+    FloatBorder = {fg = c.border_highlight},
+    Pmenu = {bg = c.bg_popup, fg = c.fg}, -- Popup menu: normal item.
+    PmenuSel = {bg = util.darken(c.fg_gutter, 0.8)}, -- Popup menu: selected item.
+    PmenuSbar = {bg = util.lighten(c.bg_popup, 0.95)}, -- Popup menu: scrollbar.
+    PmenuThumb = {bg = c.fg_gutter}, -- Popup menu: Thumb of the scrollbar.
+    Question = {fg = c.blue}, -- |hit-enter| prompt and yes/no questions
+    QuickFixLine = {bg = c.bg_visual, style = "bold"}, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
+    Search = {bg = c.bg_search, fg = c.fg_search}, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
+    IncSearch = {bg = c.orange, fg = c.black}, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
+    SpecialKey = {fg = c.fg_gutter}, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
+    SpellBad = {sp = c.error, style = "undercurl"}, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.
+    SpellCap = {sp = c.warning, style = "undercurl"}, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
+    SpellLocal = {sp = c.info, style = "undercurl"}, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
+    SpellRare = {sp = c.hint, style = "undercurl"}, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
+    StatusLine = {fg = c.fg_sidebar, bg = c.bg_statusline}, -- status line of current window
+    StatusLineNC = {fg = c.fg_gutter, bg = c.bg_statusline}, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
+    TabLine = {bg = c.bg_statusline, fg = c.fg_gutter}, -- tab pages line, not active tab page label
+    TabLineFill = {bg = c.black}, -- tab pages line, where there are no labels
+    TabLineSel = {fg = c.black, bg = c.blue}, -- tab pages line, active tab page label
+    Title = {fg = c.blue, style = "bold"}, -- titles for output from ":set all", ":autocmd" etc.
+    Visual = {bg = c.bg_visual}, -- Visual mode selection
+    VisualNOS = {bg = c.bg_visual}, -- Visual mode selection when vim is "Not Owning the Selection".
+    WarningMsg = {fg = c.warning}, -- warning messages
+    Whitespace = {fg = c.fg_gutter}, -- "nbsp", "space", "tab" and "trail" in 'listchars'
+    WildMenu = {bg = c.bg_visual}, -- current match in 'wildmenu' completion
     -- These groups are not listed as default vim groups,
     -- but they are defacto standard group names for syntax highlighting.
     -- commented out groups should chain up to their "preferred" group by
     -- default,
     -- Uncomment and edit if you want more specific syntax highlighting.
 
-    Constant = { fg = c.orange }, -- (preferred) any constant
-    String = { fg = c.green }, --   a string constant: "this is a string"
-    Character = { fg = c.green }, --  a character constant: 'c', '\n'
+    Constant = {fg = c.orange}, -- (preferred) any constant
+    String = {fg = c.green}, --   a string constant: "this is a string"
+    Character = {fg = c.green}, --  a character constant: 'c', '\n'
     -- Number        = { }, --   a number constant: 234, 0xff
     -- Boolean       = { }, --  a boolean constant: TRUE, false
     -- Float         = { }, --    a floating point constant: 2.3e10
 
-    Identifier = { fg = c.red, style = config.variableStyle }, -- (preferred) any variable name
-    Function = { fg = c.blue, style = config.functionStyle }, -- function name (also: methods for classes)
-
-    Statement = { fg = c.purple }, -- (preferred) any statement
+    Identifier = {fg = c.red, style = config.variableStyle}, -- (preferred) any variable name
+    Function = {fg = c.blue, style = config.functionStyle}, -- function name (also: methods for classes)
+    Statement = {fg = c.purple}, -- (preferred) any statement
     -- Conditional   = { }, --  if, then, else, endif, switch, etc.
     -- Repeat        = { }, --   for, do, while, etc.
     -- Label         = { }, --    case, default, etc.
-    Operator = { fg = c.red }, -- "sizeof", "+", "*", etc.
-    Keyword = { fg = c.cyan, style = config.keywordStyle }, --  any other keyword
+    Operator = {fg = c.red}, -- "sizeof", "+", "*", etc.
+    Keyword = {fg = c.cyan, style = config.keywordStyle}, --  any other keyword
     -- Exception     = { }, --  try, catch, throw
 
-    PreProc = { fg = c.cyan }, -- (preferred) generic Preprocessor
+    PreProc = {fg = c.cyan}, -- (preferred) generic Preprocessor
     -- Include       = { }, --  preprocessor #include
     -- Define        = { }, --   preprocessor #define
     -- Macro         = { }, --    same as Define
     -- PreCondit     = { }, --  preprocessor #if, #else, #endif, etc.
 
-    Type = { fg = c.yellow }, -- (preferred) int, long, char, etc.
+    Type = {fg = c.yellow}, -- (preferred) int, long, char, etc.
     -- StorageClass  = { }, -- static, register, volatile, etc.
     -- Structure     = { }, --  struct, union, enum, etc.
     -- Typedef       = { }, --  A typedef
 
-    Special = { fg = c.red }, -- (preferred) any special symbol
+    Special = {fg = c.red}, -- (preferred) any special symbol
     -- SpecialChar   = { }, --  special character in a constant
     -- Tag           = { }, --    you can use CTRL-] on this
     -- Delimiter     = { }, --  character that needs attention
     -- SpecialComment= { }, -- special things inside a comment
     -- Debug         = { }, --    debugging statements
 
-    Underlined = { style = "underline" }, -- (preferred) text that stands out, HTML links
-    Bold = { style = "bold" },
-    Italic = { style = "italic" },
-
+    Underlined = {style = "underline"}, -- (preferred) text that stands out, HTML links
+    Bold = {style = "bold"},
+    Italic = {style = "italic"},
     -- ("Ignore", below, may be invisible...)
     -- Ignore = { }, -- (preferred) left blank, hidden  |hl-Ignore|
 
-    Error = { fg = c.error }, -- (preferred) any erroneous construct
-    Todo = { bg = c.yellow, fg = c.bg }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
-
-    qfLineNr = { fg = c.dark5 },
-    qfFileName = { fg = c.blue },
-
-    htmlTag = { fg = c.purple, style = "bold" },
-
+    Error = {fg = c.error}, -- (preferred) any erroneous construct
+    Todo = {bg = c.yellow, fg = c.bg}, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+    qfLineNr = {fg = c.dark5},
+    qfFileName = {fg = c.blue},
+    htmlTag = {fg = c.purple, style = "bold"},
     -- mkdHeading = { fg = c.orange, style = "bold" },
     -- mkdCode = { bg = c.bg2, fg = c.fg },
-    mkdCodeDelimiter = { bg = c.bg2, fg = c.fg },
-    mkdCodeStart = { fg = c.yellow, style = "bold" },
-    mkdCodeEnd = { fg = c.yellow, style = "bold" },
+    mkdCodeDelimiter = {bg = c.bg2, fg = c.fg},
+    mkdCodeStart = {fg = c.yellow, style = "bold"},
+    mkdCodeEnd = {fg = c.yellow, style = "bold"},
     -- mkdLink = { fg = c.blue, style = "underline" },
 
-    markdownHeadingDelimiter = { fg = c.orange, style = "bold" },
-    markdownCode = { fg = c.yellow },
-    markdownCodeBlock = { fg = c.yellow },
-    markdownH1 = { fg = c.red, style = "bold" },
-    markdownH2 = { fg = c.blue, style = "bold" },
-    markdownLinkText = { fg = c.blue, style = "underline" },
-
-    debugPC = { bg = c.bg_sidebar }, -- used for highlighting the current line in terminal-debug
-    debugBreakpoint = { bg = util.darken(c.info, 0.1), fg = c.info }, -- used for breakpoint colors in terminal-debug
-
+    markdownHeadingDelimiter = {fg = c.orange, style = "bold"},
+    markdownCode = {fg = c.yellow},
+    markdownCodeBlock = {fg = c.yellow},
+    markdownH1 = {fg = c.red, style = "bold"},
+    markdownH2 = {fg = c.blue, style = "bold"},
+    markdownLinkText = {fg = c.blue, style = "underline"},
+    debugPC = {bg = c.bg_sidebar}, -- used for highlighting the current line in terminal-debug
+    debugBreakpoint = {bg = util.darken(c.info, 0.1), fg = c.info}, -- used for breakpoint colors in terminal-debug
     -- These groups are for the native LSP client. Some other LSP clients may
     -- use these groups, or use their own. Consult your LSP client's
     -- documentation.
-    LspReferenceText = { bg = c.fg_gutter }, -- used for highlighting "text" references
-    LspReferenceRead = { bg = c.fg_gutter }, -- used for highlighting "read" references
-    LspReferenceWrite = { bg = c.fg_gutter }, -- used for highlighting "write" references
-
-    LspDiagnosticsDefaultError = { fg = c.error }, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
-    LspDiagnosticsDefaultWarning = { fg = c.warning }, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
-    LspDiagnosticsDefaultInformation = { fg = c.info }, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
-    LspDiagnosticsDefaultHint = { fg = c.hint }, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
-
-    LspDiagnosticsVirtualTextError = { bg = util.darken(c.error, 0.1), fg = c.error }, -- Used for "Error" diagnostic virtual text
-    LspDiagnosticsVirtualTextWarning = { bg = util.darken(c.warning, 0.1), fg = c.warning }, -- Used for "Warning" diagnostic virtual text
-    LspDiagnosticsVirtualTextInformation = { bg = util.darken(c.info, 0.1), fg = c.info }, -- Used for "Information" diagnostic virtual text
-    LspDiagnosticsVirtualTextHint = { bg = util.darken(c.hint, 0.1), fg = c.hint }, -- Used for "Hint" diagnostic virtual text
-
-    LspDiagnosticsUnderlineError = { style = "undercurl", sp = c.error }, -- Used to underline "Error" diagnostics
-    LspDiagnosticsUnderlineWarning = { style = "undercurl", sp = c.warning }, -- Used to underline "Warning" diagnostics
-    LspDiagnosticsUnderlineInformation = { style = "undercurl", sp = c.info }, -- Used to underline "Information" diagnostics
-    LspDiagnosticsUnderlineHint = { style = "undercurl", sp = c.hint }, -- Used to underline "Hint" diagnostics
+    LspReferenceText = {bg = c.fg_gutter}, -- used for highlighting "text" references
+    LspReferenceRead = {bg = c.fg_gutter}, -- used for highlighting "read" references
+    LspReferenceWrite = {bg = c.fg_gutter}, -- used for highlighting "write" references
+    LspDiagnosticsDefaultError = {fg = c.error}, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    LspDiagnosticsDefaultWarning = {fg = c.warning}, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    LspDiagnosticsDefaultInformation = {fg = c.info}, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    LspDiagnosticsDefaultHint = {fg = c.hint}, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    LspDiagnosticsVirtualTextError = {bg = util.darken(c.error, 0.1), fg = c.error}, -- Used for "Error" diagnostic virtual text
+    LspDiagnosticsVirtualTextWarning = {bg = util.darken(c.warning, 0.1), fg = c.warning}, -- Used for "Warning" diagnostic virtual text
+    LspDiagnosticsVirtualTextInformation = {bg = util.darken(c.info, 0.1), fg = c.info}, -- Used for "Information" diagnostic virtual text
+    LspDiagnosticsVirtualTextHint = {bg = util.darken(c.hint, 0.1), fg = c.hint}, -- Used for "Hint" diagnostic virtual text
+    LspDiagnosticsUnderlineError = {style = "undercurl", sp = c.error}, -- Used to underline "Error" diagnostics
+    LspDiagnosticsUnderlineWarning = {style = "undercurl", sp = c.warning}, -- Used to underline "Warning" diagnostics
+    LspDiagnosticsUnderlineInformation = {style = "undercurl", sp = c.info}, -- Used to underline "Information" diagnostics
+    LspDiagnosticsUnderlineHint = {style = "undercurl", sp = c.hint} -- Used to underline "Hint" diagnostics
 
     -- LspDiagnosticsFloatingError         = { }, -- Used to color "Error" diagnostic messages in diagnostics float
     -- LspDiagnosticsFloatingWarning       = { }, -- Used to color "Warning" diagnostic messages in diagnostics float
@@ -183,9 +172,7 @@ function M.setup(config)
     -- LspDiagnosticsSignHint              = { }, -- Used for "Hint" signs in sign column
   }
 
-
   theme.plugins = {
-
     -- These groups are for the neovim tree-sitter highlights.
     -- As of writing, tree-sitter support is a WIP, group names may change.
     -- By default, most of these groups link to an appropriate Vim group,
@@ -197,50 +184,49 @@ function M.setup(config)
     -- TSBoolean           = { };    -- For booleans.
     -- TSCharacter         = { };    -- For characters.
     -- TSComment           = { };    -- For comment blocks.
-    TSNote = { fg = c.bg, bg = c.info },
-    TSWarning = { fg = c.bg, bg = c.warning },
-    TSDanger = { fg = c.bg, bg = c.error },
-    TSConstructor = { fg = c.red }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
+    TSNote = {fg = c.bg, bg = c.info},
+    TSWarning = {fg = c.bg, bg = c.warning},
+    TSDanger = {fg = c.bg, bg = c.error},
+    TSConstructor = {fg = c.red}, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
     -- TSConditional       = { };    -- For keywords related to conditionnals.
-    TSConstant          = { fg = c.yellow };    -- For constants
+    TSConstant = {fg = c.yellow}, -- For constants
     -- TSConstBuiltin      = { };    -- For constant that are built in the language: `nil` in Lua.
     -- TSConstMacro        = { };    -- For constants that are defined by macros: `NULL` in C.
     -- TSError             = { };    -- For syntax/parser errors.
     -- TSException         = { };    -- For exception related keywords.
-    TSField = { fg = c.cyan }, -- For fields.
+    TSField = {fg = c.cyan}, -- For fields.
     -- TSFloat             = { };    -- For floats.
     -- TSFunction          = { };    -- For function (calls and definitions).
     -- TSFuncBuiltin       = { };    -- For builtin functions: `table.insert` in Lua.
     -- TSFuncMacro         = { };    -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
-    TSInclude           = { fg = c.purple };    -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
-    TSKeyword = { fg = c.purple, style = config.keywordStyle }, -- For keywords that don't fall in previous categories.
-    TSKeywordFunction = { fg = c.purple, style = config.functionStyle }, -- For keywords used to define a fuction.
-    TSLabel = { fg = c.blue }, -- For labels: `label:` in C and `:label:` in Lua.
+    TSInclude = {fg = c.purple}, -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
+    TSKeyword = {fg = c.purple, style = config.keywordStyle}, -- For keywords that don't fall in previous categories.
+    TSKeywordFunction = {fg = c.purple, style = config.functionStyle}, -- For keywords used to define a fuction.
+    TSLabel = {fg = c.blue}, -- For labels: `label:` in C and `:label:` in Lua.
     -- TSMethod            = { };    -- For method calls and definitions.
-    TSNamespace         = { fg = c.red };    -- For identifiers referring to modules and namespaces.
+    TSNamespace = {fg = c.red}, -- For identifiers referring to modules and namespaces.
     -- TSNone              = { };    -- TODO: docs
     -- TSNumber            = { };    -- For all numbers
-    TSOperator = { fg = c.fg }, -- For any operator: `+`, but also `->` and `*` in C.
-    TSParameter = { fg = c.red }, -- For parameters of a function.
+    TSOperator = {fg = c.fg}, -- For any operator: `+`, but also `->` and `*` in C.
+    TSParameter = {fg = c.red}, -- For parameters of a function.
     -- TSParameterReference= { };    -- For references to parameters of a function.
-    TSProperty = { fg = c.red }, -- Same as `TSField`.
-    TSPunctDelimiter = { fg = c.fg }, -- For delimiters ie: `.`
-    TSPunctBracket = { fg = c.fg_dark }, -- For brackets and parens.
-    TSPunctSpecial = { fg = c.fg }, -- For special punctutation that does not fall in the catagories before.
+    TSProperty = {fg = c.red}, -- Same as `TSField`.
+    TSPunctDelimiter = {fg = c.fg}, -- For delimiters ie: `.`
+    TSPunctBracket = {fg = c.fg_dark}, -- For brackets and parens.
+    TSPunctSpecial = {fg = c.fg}, -- For special punctutation that does not fall in the catagories before.
     -- TSRepeat            = { };    -- For keywords related to loops.
     -- TSString            = { };    -- For strings.
-    TSStringRegex = { fg = c.orange }, -- For regexes.
-    TSStringEscape = { fg = c.red }, -- For escape characters within a string.
+    TSStringRegex = {fg = c.orange}, -- For regexes.
+    TSStringEscape = {fg = c.red}, -- For escape characters within a string.
     -- TSSymbol            = { };    -- For identifiers referring to symbols or atoms.
     -- TSType              = { };    -- For types.
     -- TSTypeBuiltin       = { };    -- For builtin types.
-    TSVariable = { style = config.variableStyle }, -- Any variable name that does not have another highlight.
-    TSVariableBuiltin = { fg = c.red }, -- Variable names that are defined by the languages, like `this` or `self`.
-
-    TSTag               = { fg = c.red };    -- Tags like html tag names.
+    TSVariable = {style = config.variableStyle}, -- Any variable name that does not have another highlight.
+    TSVariableBuiltin = {fg = c.red}, -- Variable names that are defined by the languages, like `this` or `self`.
+    TSTag = {fg = c.red}, -- Tags like html tag names.
     -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`
     -- TSText              = { };    -- For strings considered text in a markup language.
-    TSTextReference = { fg = c.red }, -- FIXME
+    TSTextReference = {fg = c.red}, -- FIXME
     -- TSEmphasis          = { };    -- For text to be represented with emphasis.
     -- TSUnderline         = { };    -- For text to be represented with an underline.
     -- TSStrike            = { };    -- For strikethrough text.
@@ -252,105 +238,92 @@ function M.setup(config)
     -- luaTSProperty = { fg = c.red }, -- Same as `TSField`.
 
     -- LspTrouble
-    LspTroubleText = { fg = c.fg_dark },
-    LspTroubleCount = { fg = c.purple, bg = c.fg_gutter },
-    LspTroubleNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
-
+    LspTroubleText = {fg = c.fg_dark},
+    LspTroubleCount = {fg = c.purple, bg = c.fg_gutter},
+    LspTroubleNormal = {fg = c.fg_sidebar, bg = c.bg_sidebar},
     -- Illuminate
-    illuminatedWord = { bg = c.fg_gutter },
-    illuminatedCurWord = { bg = c.fg_gutter },
-
+    illuminatedWord = {bg = c.fg_gutter},
+    illuminatedCurWord = {bg = c.fg_gutter},
     -- diff
-    diffAdded = { fg = c.git.add },
-    diffRemoved = { fg = c.git.delete },
-    diffChanged = { fg = c.git.change },
-    diffOldFile = { fg = c.yellow },
-    diffNewFile = { fg = c.orange },
-    diffFile = { fg = c.blue },
-    diffLine = { fg = c.fg_gutter },
-    diffIndexLine = { fg = c.purple },
-
+    diffAdded = {fg = c.git.add},
+    diffRemoved = {fg = c.git.delete},
+    diffChanged = {fg = c.git.change},
+    diffOldFile = {fg = c.yellow},
+    diffNewFile = {fg = c.orange},
+    diffFile = {fg = c.blue},
+    diffLine = {fg = c.fg_gutter},
+    diffIndexLine = {fg = c.purple},
     -- Neogit
-    NeogitBranch = { fg = c.purple },
-    NeogitRemote = { fg = c.purple },
-    NeogitHunkHeader = { bg = c.bg_highlight, fg = c.fg },
-    NeogitHunkHeaderHighlight = { bg = c.fg_gutter, fg = c.blue },
-    NeogitDiffContextHighlight = { bg = util.darken(c.fg_gutter, 0.5), fg = c.fg_dark },
-    NeogitDiffDeleteHighlight = { fg = c.git.delete, bg = c.diff.delete },
-    NeogitDiffAddHighlight = { fg = c.git.add, bg = c.diff.add },
-
+    NeogitBranch = {fg = c.purple},
+    NeogitRemote = {fg = c.purple},
+    NeogitHunkHeader = {bg = c.bg_highlight, fg = c.fg},
+    NeogitHunkHeaderHighlight = {bg = c.fg_gutter, fg = c.blue},
+    NeogitDiffContextHighlight = {bg = util.darken(c.fg_gutter, 0.5), fg = c.fg_dark},
+    NeogitDiffDeleteHighlight = {fg = c.git.delete, bg = c.diff.delete},
+    NeogitDiffAddHighlight = {fg = c.git.add, bg = c.diff.add},
     -- GitGutter
-    GitGutterAdd = { fg = c.gitSigns.add }, -- diff mode: Added line |diff.txt|
-    GitGutterChange = { fg = c.gitSigns.change }, -- diff mode: Changed line |diff.txt|
-    GitGutterDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
-
+    GitGutterAdd = {fg = c.gitSigns.add}, -- diff mode: Added line |diff.txt|
+    GitGutterChange = {fg = c.gitSigns.change}, -- diff mode: Changed line |diff.txt|
+    GitGutterDelete = {fg = c.gitSigns.delete}, -- diff mode: Deleted line |diff.txt|
     -- GitSigns
-    GitSignsAdd = { fg = c.gitSigns.add }, -- diff mode: Added line |diff.txt|
-    GitSignsChange = { fg = c.gitSigns.change }, -- diff mode: Changed line |diff.txt|
-    GitSignsDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
-
+    GitSignsAdd = {fg = c.gitSigns.add}, -- diff mode: Added line |diff.txt|
+    GitSignsChange = {fg = c.gitSigns.change}, -- diff mode: Changed line |diff.txt|
+    GitSignsDelete = {fg = c.gitSigns.delete}, -- diff mode: Deleted line |diff.txt|
     -- Telescope
-    TelescopeBorder = { fg = c.border_highlight },
-
+    TelescopeBorder = {fg = c.border_highlight},
     -- NvimTree
-    NvimTreeNormal = { fg = c.fg_light, bg = c.bg_sidebar },
-    NvimTreeRootFolder = { fg = c.yellow, style = "bold" },
-    NvimTreeGitDirty = { fg = c.yellow2 },
-    NvimTreeGitNew = { fg = c.git.add },
-    NvimTreeGitDeleted = { fg = c.git.delete },
-    NvimTreeSpecialFile = { fg = c.yellow, style = "underline" },
-    NvimTreeIndentMarker = { fg = c.fg_gutter },
-    NvimTreeImageFile = { fg = c.fg_sidebar },
-    NvimTreeSymlink = { fg = c.purple },
-    NvimTreeFolderName= { fg = c.blue },
-    LspDiagnosticsError = { fg = c.error },
-    LspDiagnosticsWarning = { fg = c.warning },
-    LspDiagnosticsInformation = { fg = c.info },
-    LspDiagnosticsHint = { fg = c.hint },
-
+    NvimTreeNormal = {fg = c.fg_light, bg = c.bg_sidebar},
+    NvimTreeRootFolder = {fg = c.fg_light, style = "bold"},
+    NvimTreeGitDirty = {fg = c.yellow2},
+    NvimTreeGitNew = {fg = c.git.add},
+    NvimTreeGitDeleted = {fg = c.git.delete},
+    NvimTreeSpecialFile = {fg = c.yellow, style = "underline"},
+    NvimTreeIndentMarker = {fg = c.fg_gutter},
+    NvimTreeImageFile = {fg = c.fg_sidebar},
+    NvimTreeSymlink = {fg = c.purple},
+    NvimTreeFolderName = {fg = c.fg_light},
+    LspDiagnosticsError = {fg = c.error},
+    LspDiagnosticsWarning = {fg = c.warning},
+    LspDiagnosticsInformation = {fg = c.info},
+    LspDiagnosticsHint = {fg = c.hint},
     -- Dashboard
-    DashboardShortCut = { fg = c.purple },
-    DashboardHeader = { fg = c.red },
-    DashboardCenter = { fg = c.blue },
-    DashboardFooter = { fg = c.yellow, style = "italic" },
-
+    DashboardShortCut = {fg = c.purple},
+    DashboardHeader = {fg = c.red},
+    DashboardCenter = {fg = c.blue},
+    DashboardFooter = {fg = c.yellow, style = "italic"},
     -- WhichKey
-    WhichKey = { fg = c.yellow },
-    WhichKeyGroup = { fg = c.blue },
-    WhichKeyDesc = { fg = c.red },
-    WhichKeySeperator = { fg = c.fg_gutter },
-    WhichKeySeparator = { fg = c.fg_gutter },
-    WhichKeyFloat = { bg = c.bg_sidebar },
-    WhichKeyValue = { fg = c.dark5 },
-
+    WhichKey = {fg = c.yellow},
+    WhichKeyGroup = {fg = c.blue},
+    WhichKeyDesc = {fg = c.red},
+    WhichKeySeperator = {fg = c.fg_gutter},
+    WhichKeySeparator = {fg = c.fg_gutter},
+    WhichKeyFloat = {bg = c.bg_sidebar},
+    WhichKeyValue = {fg = c.dark5},
     -- LspSaga
-    DiagnosticError = { fg = c.error },
-    DiagnosticWarning = { fg = c.warning },
-    DiagnosticInformation = { fg = c.info },
-    DiagnosticHint = { fg = c.hint },
-
+    DiagnosticError = {fg = c.error},
+    DiagnosticWarning = {fg = c.warning},
+    DiagnosticInformation = {fg = c.info},
+    DiagnosticHint = {fg = c.hint},
     -- NeoVim
-    healthError = { fg = c.error },
-    healthSuccess = { fg = c.green },
-    healthWarning = { fg = c.warning },
-
+    healthError = {fg = c.error},
+    healthSuccess = {fg = c.green},
+    healthWarning = {fg = c.warning},
     -- BufferLine
-    BufferLineIndicatorSelected = { fg = c.git.change },
-    BufferLineFill = { bg = c.black },
-
+    BufferLineIndicatorSelected = {fg = c.git.change},
+    BufferLineFill = {bg = c.black},
     -- ALE
-    ALEWarningSign = { fg = c.yellow },
-    ALEErrorSign   = { fg = c.red },
+    ALEWarningSign = {fg = c.yellow},
+    ALEErrorSign = {fg = c.red}
   }
 
   if config.hideInactiveStatusline then
-    local inactive = { style = "underline", bg = c.bg, fg = c.bg, sp = c.border }
+    local inactive = {style = "underline", bg = c.bg, fg = c.bg, sp = c.border}
 
     -- StatusLineNC
     theme.base.StatusLineNC = inactive
 
     -- LuaLine
-    for _, section in ipairs({ "a", "b", "c" }) do
+    for _, section in ipairs({"a", "b", "c"}) do
       theme.plugins["lualine_" .. section .. "_inactive"] = inactive
     end
   end

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -32,7 +32,7 @@ function M.setup(config)
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal
     ErrorMsg = {fg = c.error}, -- error messages on the command line
-    VertSplit = {fg = c.border}, -- the column separating vertically split windows
+    VertSplit = {fg = c.bg2}, -- the column separating vertically split windows
     Folded = {fg = c.blue, bg = c.fg_gutter}, -- line used for closed folds
     FoldColumn = {bg = c.bg, fg = c.fg_gutter}, -- 'foldcolumn'
     SignColumn = {bg = config.transparent and c.none or c.bg, fg = c.fg_gutter}, -- column where |signs| are displayed
@@ -273,6 +273,7 @@ function M.setup(config)
     TelescopeBorder = {fg = c.border_highlight},
     -- NvimTree
     NvimTreeNormal = {fg = c.fg_light, bg = c.bg_sidebar},
+    NvimTreeEndOfBuffer = {fg = c.bg2},
     NvimTreeRootFolder = {fg = c.fg_light, style = "bold"},
     NvimTreeGitDirty = {fg = c.yellow2},
     NvimTreeGitNew = {fg = c.git.add},

--- a/lua/onedark/util.lua
+++ b/lua/onedark/util.lua
@@ -16,7 +16,7 @@ local function hexToRgb(hex_str)
   assert(string.find(hex_str, pat) ~= nil, "hex_to_rgb: invalid hex_str: " .. tostring(hex_str))
 
   local r, g, b = string.match(hex_str, pat)
-  return { tonumber(r, 16), tonumber(g, 16), tonumber(b, 16) }
+  return {tonumber(r, 16), tonumber(g, 16), tonumber(b, 16)}
 end
 
 ---@param fg string foreground color
@@ -161,9 +161,12 @@ end
 ---@param str string template string
 ---@param table table key value pairs to replace in the string
 function util.template(str, table)
-  return (str:gsub("($%b{})", function(w)
-    return table[w:sub(3, -2)] or w
-  end))
+  return (str:gsub(
+    "($%b{})",
+    function(w)
+      return table[w:sub(3, -2)] or w
+    end
+  ))
 end
 
 function util.syntax(syntax)
@@ -233,11 +236,14 @@ function util.load(theme)
   util.syntax(theme.base)
 
   -- load syntax for plugins and terminal async
-  vim.defer_fn(function()
-    util.terminal(theme.colors)
-    util.syntax(theme.plugins)
-    util.autocmds(theme.config)
-  end, 0)
+  vim.defer_fn(
+    function()
+      util.terminal(theme.colors)
+      util.syntax(theme.plugins)
+      util.autocmds(theme.config)
+    end,
+    0
+  )
 end
 
 ---@param config Config
@@ -265,7 +271,7 @@ end
 function util.light(brightness)
   for hl_name, hl in pairs(vim.api.nvim__get_hl_defs(0)) do
     local def = {}
-    for key, def_key in pairs({ foreground = "fg", background = "bg", special = "sp" }) do
+    for key, def_key in pairs({foreground = "fg", background = "bg", special = "sp"}) do
       if type(hl[key]) == "number" then
         local hex = string.format("#%06x", hl[key])
         local color = util.invertColor(hex)
@@ -276,7 +282,7 @@ function util.light(brightness)
       end
     end
     if hl_name ~= "" and #def > 0 then
-      for _, style in pairs({ "bold", "italic", "underline", "undercurl", "reverse" }) do
+      for _, style in pairs({"bold", "italic", "underline", "undercurl", "reverse"}) do
         if hl[style] then
           table.insert(def, "gui=" .. style)
         end
@@ -291,7 +297,7 @@ function util.random()
   local colors = {}
   for hl_name, hl in pairs(vim.api.nvim__get_hl_defs(0)) do
     local def = {}
-    for key, def_key in pairs({ foreground = "fg", background = "bg", special = "sp" }) do
+    for key, def_key in pairs({foreground = "fg", background = "bg", special = "sp"}) do
       if type(hl[key]) == "number" then
         local hex = string.format("#%06x", hl[key])
         local color = colors[hex] and colors[hex] or util.randomColor(hex)
@@ -300,7 +306,7 @@ function util.random()
       end
     end
     if hl_name ~= "" and #def > 0 then
-      for _, style in pairs({ "bold", "italic", "underline", "undercurl", "reverse" }) do
+      for _, style in pairs({"bold", "italic", "underline", "undercurl", "reverse"}) do
         if hl[style] then
           table.insert(def, "gui=" .. style)
         end


### PR DESCRIPTION
Previously `bg_highlight` set from the blue family. That only able to make contrast in `sidebar` windows, If `onedark_dark_sidebar` is set. This color tweak makes `bg_highlight` pop in light and dark background .

Also, I formated the `lua/onedark/colors.lua` file with `luafmt`.

## Changes Preview

### Patch
![After](https://imgur.com/cOQlY5A.png)

### Before
![Before](https://i.imgur.com/ECrdMLY.png)


