### PR TITLE
fixed monsonjeremy/onedark.nvim#6: add `onedark_hide_nontext` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ let g:lightline = {'colorscheme': 'onedark'}
 | onedark_italic_variables         | `false` | Make variables and identifiers italic                                                                                                                           |
 | onedark_transparent              | `false` | Enable this to disable setting the background color                                                                                                             |
 | onedark_hide_inactive_statusline | `false` | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
+| onedark_hide_nontext             | `false` | Enabling this option, will hide filler lines (~) after the end of the buffer                                                                                    |
 | onedark_sidebars                 | `{}`    | Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`                                                      |
 | onedark_dark_sidebar             | `true`  | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
 | onedark_dark_float               | `true`  | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -22,6 +22,7 @@ config = {
   functionStyle = opt("italic_functions", false) and "italic" or "NONE",
   variableStyle = opt("italic_variables", false) and "italic" or "NONE",
   hideInactiveStatusline = opt("hide_inactive_statusline", false),
+  hideNonText = opt("hide_nontext", true),
   sidebars = opt("sidebars", {}),
   colors = opt("colors", {}),
   dev = opt("dev", false),

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -28,7 +28,7 @@ function M.setup(config)
     DiffChange = { bg = c.diff.change }, -- diff mode: Changed line |diff.txt|
     DiffDelete = { bg = c.diff.delete }, -- diff mode: Deleted line |diff.txt|
     DiffText = { bg = c.diff.text }, -- diff mode: Changed text within a changed line |diff.txt|
-    EndOfBuffer = { fg = c.bg }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+    EndOfBuffer = { fg = config.hideNonText and c.bg or c.fg_dark }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal
     ErrorMsg = { fg = c.error }, -- error messages on the command line


### PR DESCRIPTION
### Fixes:
- add `onedark_hide_nontext` option ( fixed monsonjeremy/onedark.nvim#6)

### Patch Preview

https://user-images.githubusercontent.com/24286590/125449985-bb612e12-6e88-4fe1-bff0-43d7a2396ebb.mp4

