### PR TITLE
Repatch ful1e5/onedark#2 with performance tweak

### DIFF
--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -366,6 +366,8 @@ function M.setup(config)
     LightspeedGreyWash = { fg = c.dark5 },
   }
 
+  theme.defer = {}
+
   if config.hideInactiveStatusline then
     local inactive = { style = "underline", bg = c.bg, fg = c.bg, sp = c.bg_visual }
 
@@ -380,7 +382,7 @@ function M.setup(config)
 
       -- LuaLine
       for _, section in pairs({ "a", "b", "c" }) do
-        theme.plugins["lualine_" .. section .. "_inactive"] = inactive
+        theme.defer["lualine_" .. section .. "_inactive"] = inactive
       end
     end
   end

--- a/lua/onedark/util.lua
+++ b/lua/onedark/util.lua
@@ -214,11 +214,12 @@ function util.load(theme)
   util.syntax(theme.base)
 
   -- load syntax for plugins and terminal async
+  util.terminal(theme.colors)
+  util.syntax(theme.plugins)
+  util.autocmds(theme.config)
   vim.defer_fn(function()
-    util.terminal(theme.colors)
-    util.syntax(theme.plugins)
-    util.autocmds(theme.config)
-  end, 0)
+    util.syntax(theme.defer)
+  end, 100)
 end
 
 ---@param colors ColorScheme


### PR DESCRIPTION

### Neovim startup time  with `nvim --startuptime vim.log`

```diff
- 214.861  000.024  000.024: sourcing /home/kaiz/GitHub/ful1e5/onedark.nvim-1/colors/onedark.vim
- 215.771  001.043  001.019: sourcing /usr/share/nvim/runtime/syntax/synload.vim
- 215.874  001.804  000.203: sourcing /usr/share/nvim/runtime/syntax/syntax.vim

+ 207.261  000.024  000.024: sourcing /home/kaiz/GitHub/ful1e5/onedark.nvim-1/colors/onedark.vim
+ 208.128  000.998  000.974: sourcing /usr/share/nvim/runtime/syntax/synload.vim
+ 208.218  001.643  000.197: sourcing /usr/share/nvim/runtime/syntax/syntax.vim
```